### PR TITLE
Remove link to incomplete Projects page

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -83,9 +83,6 @@ function Header() {
 						<HeaderNavLink href="/history">History</HeaderNavLink>
 					</li>
 					<li>
-						<HeaderNavLink href="/projects">Projects</HeaderNavLink>
-					</li>
-					<li>
 						<HeaderNavLink href="/snakedex">Snakedex</HeaderNavLink>
 					</li>
 					<li>


### PR DESCRIPTION
It looks dumb/weird to have those projects up.  The URL will still work fine for us to test the page until it's ready