### PR TITLE
Allow using environment variables to configure URLs

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_WEBSITE_BASE=https://snakeroom.org
+NEXT_PUBLIC_API_BASE=https://api.snakeroom.org
+NEXT_PUBLIC_SNAKEDEX_BASE=https://snakeroom.github.io/Snakedex

--- a/components/account-dropdown.js
+++ b/components/account-dropdown.js
@@ -3,6 +3,7 @@ import { faUser } from "@fortawesome/free-solid-svg-icons";
 import NextLink from "next/link";
 import HeaderButton from "./header-button";
 import StateContext from "../lib/state";
+import { API_BASE, WEBSITE_BASE } from "../lib/api";
 
 function AccountDropdown() {
 	return (
@@ -14,7 +15,11 @@ function AccountDropdown() {
 							<FontAwesomeIcon icon={faUser} />
 						</NextLink>
 					) : (
-						<a href="https://api.snakeroom.org/identity/reddit/login?return_to=https%3A%2F%2Fsnakeroom.org%2Faccount">
+						<a
+							href={`${API_BASE}/identity/reddit/login?return_to=${encodeURIComponent(
+								`${WEBSITE_BASE}/account`
+							)}`}
+						>
 							<FontAwesomeIcon icon={faUser} />
 						</a>
 					)

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,6 @@
-export const API_BASE = "https://api.snakeroom.org";
-export const SNAKEDEX_BASE = "https://snakeroom.github.io/Snakedex";
+export const WEBSITE_BASE = process.env.NEXT_PUBLIC_WEBSITE_BASE;
+export const API_BASE = process.env.NEXT_PUBLIC_API_BASE;
+export const SNAKEDEX_BASE = process.env.NEXT_PUBLIC_SNAKEDEX_BASE;
 
 export const makeApiRequest = (path, fetchParams) => {
 	return fetch(API_BASE + path, {

--- a/pages/account.js
+++ b/pages/account.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import StateContext from "../lib/state";
 import Link from "../components/link";
 import { PageTitle } from "../lib/common-style";
+import { API_BASE } from "../lib/api";
 
 const Container = styled.div`
 	font-size: 1.5rem;
@@ -30,7 +31,7 @@ export default function AccountPage() {
 								<Link href="/edit_profile">Edit Profile</Link>
 								<br />
 								{userState.user.is_staff && (
-									<Link href="https://api.snakeroom.org/admin">
+									<Link href={`${API_BASE}/admin`}>
 										Admin Console
 									</Link>
 								)}

--- a/pages/edit_profile.js
+++ b/pages/edit_profile.js
@@ -1,6 +1,6 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { API_BASE } from "../lib/api";
+import { makeApiRequest } from "../lib/api";
 import { Box, PageTitle } from "../lib/common-style";
 import StateContext from "../lib/state";
 import SubmitButton, { StyledInput } from "../components/submit-button";
@@ -24,10 +24,9 @@ export default function EditProfilePage({ dispatch }) {
 			else payload.append(name, element.value);
 		}
 
-		fetch(`${API_BASE}/identity/@me/profile/`, {
+		makeApiRequest("/identity/@me/profile/", {
 			method: "POST",
 			body: payload,
-			credentials: "include",
 		})
 			.then(() => {
 				dispatch({ type: "mark" });


### PR DESCRIPTION
With this pull request, developers can specify development URLs in `.env.local`:

```sh
NEXT_PUBLIC_WEBSITE_BASE=http://localhost:3000
NEXT_PUBLIC_API_BASE=http://localhost:8000
```